### PR TITLE
Fix Typo in GpuNamedConstantsSerializer::exportNamedConstants

### DIFF
--- a/OgreMain/src/OgreGpuProgramParams.cpp
+++ b/OgreMain/src/OgreGpuProgramParams.cpp
@@ -291,7 +291,7 @@ namespace Ogre
         {
             OGRE_EXCEPT(Exception::ERR_CANNOT_WRITE_TO_FILE,
                         "Unable to write to stream " + stream->getName(),
-                        "GpuNamedConstantsSerializer::exportSkeleton");
+                        "GpuNamedConstantsSerializer::exportNamedConstants");
         }
 
         writeFileHeader();


### PR DESCRIPTION
There was a typo wich would lead to misleading OGRE Exception text.